### PR TITLE
SP adjust processing fix

### DIFF
--- a/src/contracts/stability-pool/transactions.ts
+++ b/src/contracts/stability-pool/transactions.ts
@@ -491,9 +491,7 @@ export async function processSpRequest(
           stabilityPoolUtxo.assets[
             params.stabilityPoolParams.assetSymbol.unCurrencySymbol +
               fromText(asset)
-          ] +
-          balanceChange +
-          withdrawalFee,
+          ] ?? 0n + balanceChange + withdrawalFee,
       },
     );
     tx.pay.ToContract(


### PR DESCRIPTION
In case of partial liquidation, the SP gets emptied, and the arithmetics would fail.